### PR TITLE
[auth] 분리된 OAuth2/기본 보안 체인 충돌 해결

### DIFF
--- a/src/main/java/com/koa/RingDong/global/config/OAuth2Config.java
+++ b/src/main/java/com/koa/RingDong/global/config/OAuth2Config.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -25,7 +26,15 @@ public class OAuth2Config {
     private static final String LOGOUT_URL = "/";
 
     @Bean
+    @Order(1)
     public SecurityFilterChain oauth2SecurityFilterChain(HttpSecurity http) throws Exception {
+
+        http.securityMatcher(
+                OAUTH2_AUTHORIZATION_BASE_URI + "/**",
+                "/oauth2/**",
+                "/login/**"
+        );
+
         http
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(endpoint -> endpoint

--- a/src/main/java/com/koa/RingDong/global/config/SecurityConfig.java
+++ b/src/main/java/com/koa/RingDong/global/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -50,6 +51,7 @@ public class SecurityConfig {
     private static final String LOGOUT_URL = "/";
 
     @Bean
+    @Order(2)
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .csrf(csrf -> csrf.disable())


### PR DESCRIPTION
- oauth2SecurityFilterChain에 securityMatcher 및 @Order(1) 적용
- apiSecurityFilterChain을 @Order(2)로 지정하여 catch-all 체인으로 동작
- anyRequest 충돌로 인해 발생하던 filter chain override 문제 수정