### PR TITLE
fix: /api/auth/refresh 시 헤더 처리

### DIFF
--- a/src/main/java/com/koa/koalamailman/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/koa/koalamailman/domain/auth/controller/AuthController.java
@@ -5,9 +5,7 @@ import com.koa.koalamailman.domain.auth.dto.AccessTokenResponse;
 import com.koa.koalamailman.domain.auth.service.RefreshTokenService;
 import com.koa.koalamailman.global.dto.SuccessResponse;
 import com.koa.koalamailman.global.exception.SuccessCode;
-import com.koa.koalamailman.global.security.oauth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,12 +20,11 @@ public class AuthController implements AuthControllerDocs {
 
     @PostMapping("/refresh")
     public SuccessResponse<AccessTokenResponse> refreshAccessToken(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
             @CookieValue(value = "refresh_token") String refreshToken
     ) {
         return SuccessResponse.success(
                 SuccessCode.GET_ACCESS_TOKEN,
-                AccessTokenResponse.from(refreshTokenService.validateAndGenerateAccessToken(userDetails.getUser(), refreshToken))
+                AccessTokenResponse.from(refreshTokenService.validateAndGenerateAccessToken(refreshToken))
         );
     }
 }

--- a/src/main/java/com/koa/koalamailman/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/koa/koalamailman/domain/auth/controller/docs/AuthControllerDocs.java
@@ -2,16 +2,12 @@ package com.koa.koalamailman.domain.auth.controller.docs;
 
 import com.koa.koalamailman.domain.auth.dto.AccessTokenResponse;
 import com.koa.koalamailman.global.dto.SuccessResponse;
-import com.koa.koalamailman.global.security.oauth.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 
-@SecurityRequirement(name = "Authorization")
 @Tag(name = "로그인, 인증", description = "로그인 인증 관련 API입니다.")
 public interface AuthControllerDocs {
     @Operation(
@@ -46,6 +42,7 @@ public interface AuthControllerDocs {
     )
     default void naverLogin() {}
 
+    @SecurityRequirement(name = "Authorization")
     @Operation(
             summary = "로그아웃 [POST] /api/auth/logout",
             responses = {
@@ -67,8 +64,6 @@ public interface AuthControllerDocs {
             }
     )
     public SuccessResponse<AccessTokenResponse> refreshAccessToken(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal CustomUserDetails userDetails,
             @CookieValue(value = "refresh_token") String refreshToken
     );
 }

--- a/src/main/java/com/koa/koalamailman/domain/auth/service/AccessTokenService.java
+++ b/src/main/java/com/koa/koalamailman/domain/auth/service/AccessTokenService.java
@@ -14,6 +14,6 @@ public class AccessTokenService {
     private long accessExpirationTimeMs;
 
     public String createAccessToken(User user) {
-        return jwtProvider.generateToken(user, accessExpirationTimeMs);
+        return jwtProvider.generateToken(user.getId(), user.getEmail(), accessExpirationTimeMs);
     }
 }

--- a/src/main/java/com/koa/koalamailman/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/koa/koalamailman/domain/auth/service/RefreshTokenService.java
@@ -29,8 +29,9 @@ public class RefreshTokenService {
     private long refreshTokenExpirationMs;
 
     @Transactional
-    public String validateAndGenerateAccessToken(User user, String rawRefreshToken) {
-        RefreshToken refreshToken = findByUserId(user.getId());
+    public String validateAndGenerateAccessToken(String rawRefreshToken) {
+        Long userId = Long.parseLong(jwtProvider.getSubjectFromToken(rawRefreshToken));
+        RefreshToken refreshToken = findByUserId(userId);
 
         byte[] incomingHash = hmacSha256(secretKey, rawRefreshToken);
 
@@ -42,11 +43,11 @@ public class RefreshTokenService {
             throw new BaseException(AuthErrorCode.UNAUTHORIZED);
         }
 
-        return jwtProvider.generateToken(user, refreshTokenExpirationMs);
+        return jwtProvider.generateToken(userId, null, refreshTokenExpirationMs);
     }
     @Transactional
     public String createRefreshToken(User user) {
-        String rawToken = jwtProvider.generateToken(user, refreshTokenExpirationMs);
+        String rawToken = jwtProvider.generateToken(user.getId(), null, refreshTokenExpirationMs);
         byte[] tokenHash = hmacSha256(secretKey, rawToken);
         LocalDateTime expiresAt = LocalDateTime.now().plus(Duration.ofMillis(refreshTokenExpirationMs));
 

--- a/src/main/java/com/koa/koalamailman/global/config/SecurityConfig.java
+++ b/src/main/java/com/koa/koalamailman/global/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
             "/", "/error",
             "/actuator/health", "/actuator/health/**",
             // OAuth2
-            "/oauth2/**", "/login/**",
+            "/oauth2/**", "/login/**", "/api/auth/refresh",
             // Login / Logout
             LOGIN_URL + "/**", LOGOUT_URL,
             // Swagger

--- a/src/main/java/com/koa/koalamailman/global/token/JwtProvider.java
+++ b/src/main/java/com/koa/koalamailman/global/token/JwtProvider.java
@@ -35,16 +35,16 @@ public class JwtProvider {
         this.algorithm = Algorithm.HMAC256(secretKey);
     }
 
-    public String generateToken(User user, long expirationTimeMs) {
+    public String generateToken(Long userId, String email, long expirationTimeMs) {
         return JWT.create()
-                .withSubject(user.getId().toString())
-                .withClaim("email", user.getEmail())
+                .withSubject(userId.toString())
+                .withClaim("email", email)
                 .withIssuedAt(new Date())
                 .withExpiresAt(new Date(System.currentTimeMillis() + expirationTimeMs))
                 .sign(algorithm);
     }
 
-    private String getSubjectFromToken(String token) {
+    public String getSubjectFromToken(String token) {
         return JWT.require(algorithm)
                 .build()
                 .verify(token)


### PR DESCRIPTION
- access token 재발급 시, 헤더에 access token 넣을 수 없음