### PR TITLE
chore: health check 전 대기 시간을 120초로 늘림

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,7 +1,7 @@
 name: Backend → Docker Hub → EC2
 on:
   push:
-    branches: ["infra/ci"]
+    branches: ["develop"]
   workflow_dispatch:
 
 jobs:
@@ -86,7 +86,7 @@ jobs:
               --cpus="0.4" \
               "$IMAGE"
             
-            # 대기 120초
+            # 대기 120
             sleep 120
 
             # Health 체크: 최대 재시도 60회, 10초 간격


### PR DESCRIPTION
## 🔖 Description
<!-- 변경 사항과 관련 이슈를 간단히 작성해주세요.
     "어떻게" 보다는 "무엇을, 왜" 수정했는지를 중점적으로 설명해주세요. -->

Resolves: #61 

- 새 컨테이너 기동 시 애플리케이션 서버가 포트를 열기 전 Health 체크 실패 방지
- 초기 대기 시간을 120초로 늘려 안정적인 Blue/Green 배포 확보
- 기존 ACTIVE 서버는 대기 시간 동안 계속 요청 처리 → 서비스 중단 없음


## 📂 PR Type
이번 PR에는 어떤 변경 사항이 포함되었나요?

- [ ] ✨ 새로운 기능 추가
- [ ] 🔨 코드 리팩토링
- [ ] 🐛 버그 수정
- [ ] ✅ 테스트 추가
- [x] 📦 빌드/패키지 매니저 수정
- [ ] 📝 주석 추가 및 수정
- [ ] 📚 문서 수정
- [ ] 🗂 파일/폴더명 수정
- [ ] 🗑 파일/폴더 삭제


## ✅ Checklist
PR이 다음 요구 사항을 충족하는지 확인해주세요.

- [x] 커밋 메시지가 컨벤션에 맞게 작성되었습니다.
- [x] `dev` 브랜치를 최신 상태로 맞추고 conflict를 해결했습니다.
- [x] 기능/버그 수정에 대한 테스트를 완료했습니다.


## 📌 ETC
<!-- 리뷰어가 참고하면 좋을 추가 사항이나 주의할 점이 있다면 적어주세요. -->
