### PR TITLE
chore: controller exception 발생 시 stacktrace는 debug 분리, 에러메세지만 출력

### DIFF
--- a/src/main/java/com/koa/koalamailman/global/logging/ControllerLoggingAspect.java
+++ b/src/main/java/com/koa/koalamailman/global/logging/ControllerLoggingAspect.java
@@ -48,12 +48,14 @@ public class ControllerLoggingAspect {
     }
 
     @AfterThrowing(pointcut = "controllerMethods()", throwing = "ex")
-    public void logAfterThrowing(JoinPoint joinPoint, Throwable ex) {
+    public void logAfterThrowing(JoinPoint joinPoint, Throwable ex) throws Throwable {
         log.error("[ERROR] Exception in {}.{}() - {}",
                 joinPoint.getSignature().getDeclaringTypeName(),
                 joinPoint.getSignature().getName(),
-                ex.getMessage(), ex);
+                ex.getMessage());
 
+        log.debug("Stacktrace: ", ex);
         MDC.clear();
+        throw ex;
     }
 }


### PR DESCRIPTION
## 🔖 Description
<!-- 변경 사항과 관련 이슈를 간단히 작성해주세요.
     "어떻게" 보다는 "무엇을, 왜" 수정했는지를 중점적으로 설명해주세요. -->

- controller logging에서 에러 trace를 전부 출력하고, throw하지 않음
- controller exception 발생 시 stacktrace는 debug 분리, 에러메세지만 출력

Resolves: #69 


## 📂 PR Type
이번 PR에는 어떤 변경 사항이 포함되었나요?

- [ ] ✨ 새로운 기능 추가
- [x] 🔨 코드 리팩토링
- [ ] 🐛 버그 수정
- [ ] ✅ 테스트 추가
- [ ] 📦 빌드/패키지 매니저 수정
- [ ] 📝 주석 추가 및 수정
- [ ] 📚 문서 수정
- [ ] 🗂 파일/폴더명 수정
- [ ] 🗑 파일/폴더 삭제


## ✅ Checklist
PR이 다음 요구 사항을 충족하는지 확인해주세요.

- [x] 커밋 메시지가 컨벤션에 맞게 작성되었습니다.
- [x] `dev` 브랜치를 최신 상태로 맞추고 conflict를 해결했습니다.
- [x] 기능/버그 수정에 대한 테스트를 완료했습니다.


## 📌 ETC
<!-- 리뷰어가 참고하면 좋을 추가 사항이나 주의할 점이 있다면 적어주세요. -->
