### PR TITLE
[#107] fix: 리마인드 메일 발송 후 다음 전송 시간 업데이트 안되는 버그 수정

### DIFF
--- a/src/main/java/com/koa/koalamailman/domain/reminder/application/usecase/ReScheduleReminderUseCase.java
+++ b/src/main/java/com/koa/koalamailman/domain/reminder/application/usecase/ReScheduleReminderUseCase.java
@@ -1,5 +1,6 @@
 package com.koa.koalamailman.domain.reminder.application.usecase;
 
+import com.koa.koalamailman.domain.mandalart.repository.MandalartRepository;
 import com.koa.koalamailman.domain.mandalart.repository.entity.MandalartEntity;
 import com.koa.koalamailman.domain.mandalart.repository.entity.ReminderOption;
 import com.koa.koalamailman.domain.reminder.application.provider.ReminderTimeProvider;
@@ -14,9 +15,13 @@ import java.time.LocalDateTime;
 public class ReScheduleReminderUseCase {
 
     private final ReminderTimeProvider reminderTimeProvider;
+    private final MandalartRepository mandalartRepository;
 
     @Transactional
-    public void rescheduleRandom(MandalartEntity mandalart) {
+    public void rescheduleRandom(Long mandalartId) {
+        MandalartEntity mandalart = mandalartRepository.findById(mandalartId).orElse(null);
+        if (mandalart == null) return;
+
         ReminderOption option = mandalart.getReminderOption();
         if (option == null) return;
         LocalDateTime nextScheduledTime = reminderTimeProvider.generateRandomTime(option.getRemindInterval());

--- a/src/main/java/com/koa/koalamailman/domain/reminder/application/usecase/ScheduleReminderUseCase.java
+++ b/src/main/java/com/koa/koalamailman/domain/reminder/application/usecase/ScheduleReminderUseCase.java
@@ -45,7 +45,7 @@ public class ScheduleReminderUseCase {
 
     private void execute(MandalartEntity mandalart) {
         reminderRemindMailService.send(mandalart);
-        reScheduleReminderUseCase.rescheduleRandom(mandalart);
+        reScheduleReminderUseCase.rescheduleRandom(mandalart.getId());
     }
 
     private long calculateDelay(LocalDateTime scheduledTime) {


### PR DESCRIPTION
## 🔖 Description
<!-- 변경 사항과 관련 이슈를 간단히 작성해주세요.
     "어떻게" 보다는 "무엇을, 왜" 수정했는지를 중점적으로 설명해주세요. -->

- 리마인드 메일 발송 후 `remindScheduledAt`이 DB에 업데이트되지 않던 버그 수정
- `ReScheduleReminderUseCase`에서 **엔티티를 직접 전달하지 않고 ID로 재조회**하도록 변경

### 문제 상황

1. 리마인드 대상 조회 (메인 스레드)
리마인드 스케줄러는 오늘 전송할 만다라트 entity를 조회한다.
이따 조회된 entity는 해당 트랜잭션 내에서는 Managed 상태이지만, 
조회 로직이 끝나면 트랜잭션이 종료되고, Detached 상태가 된다.

2. 스케줄러 등록
조회된 엔티티는 schedule()로 지연 실행 작업으로 등록된다.
(이때 Mandalart Entity는 영속성 컨텍스트와 분리된 상태)

3. 스케줄러 실행 (별도 스레드)

지연 시간 후, 별도의 스레드에서 전송 로직을 실행한다.
이때 매서드 파라미터로 전달된 만다라트 entity는 Detached 되어 있다.
따라서 **JPA의 Dirty Checking(변경 감지)가 동작하지 않았다.**

Resolves: #107


## 📂 PR Type
이번 PR에는 어떤 변경 사항이 포함되었나요?

- [ ] ✨ 새로운 기능 추가
- [ ] 🔨 코드 리팩토링
- [x] 🐛 버그 수정
- [ ] ✅ 테스트 추가
- [ ] 📦 빌드/패키지 매니저 수정
- [ ] 📝 주석 추가 및 수정
- [ ] 📚 문서 수정
- [ ] 🗂 파일/폴더명 수정
- [ ] 🗑 파일/폴더 삭제


## ✅ Checklist
PR이 다음 요구 사항을 충족하는지 확인해주세요.

- [x] 커밋 메시지가 컨벤션에 맞게 작성되었습니다.
- [ ] `dev` 브랜치를 최신 상태로 맞추고 conflict를 해결했습니다.
- [ ] 기능/버그 수정에 대한 테스트를 완료했습니다.


## 📌 ETC
<!-- 리뷰어가 참고하면 좋을 추가 사항이나 주의할 점이 있다면 적어주세요. -->

### JPA 엔티티의 생명주기

JPA 엔티티는 Persistence Context와의 관계에 따라 생명 주기를 갖는다.

1. Trasient 비영속 상태
2. Managed 영속 상태 **Dirty Checking**
3. Detached 준영속 상태
4. Removed 삭제 상태

Detached 상태는 한때는 영속 상태였지만, Persistence Context와 분리되어 있다.
Spring에서는 @Transactional 하나 당, 하나의 Persistence Context를 갖고, 트랜잭션이 끝나면 Persistence context도 종료되고 내부 엔티티들은 준영속 상태가 된다.