### PR TITLE
Refactor: OAuth 로그인 토큰 전달 개선 및 보안 이슈 수정

### DIFF
--- a/src/main/java/com/koa/koalamailman/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/koa/koalamailman/auth/application/RefreshTokenService.java
@@ -28,6 +28,9 @@ public class RefreshTokenService {
     @Value("${jwt.refresh.expiration}")
     private long refreshTokenExpirationMs;
 
+    @Value("${jwt.access.expiration}")
+    private long accessTokenExpirationMs;
+
     @Transactional
     public String validateAndGenerateAccessToken(String rawRefreshToken) {
         Long userId = Long.parseLong(jwtProvider.getSubjectFromToken(rawRefreshToken));
@@ -43,7 +46,7 @@ public class RefreshTokenService {
             throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
         }
 
-        return jwtProvider.generateToken(userId, null, refreshTokenExpirationMs);
+        return jwtProvider.generateToken(userId, null, accessTokenExpirationMs);
     }
 
     @Transactional

--- a/src/main/java/com/koa/koalamailman/global/config/SecurityConfig.java
+++ b/src/main/java/com/koa/koalamailman/global/config/SecurityConfig.java
@@ -112,7 +112,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration cfg = new CorsConfiguration();
 
-        cfg.setAllowedOrigins(List.of("http://localhost:3000", frontUri, backUri));
+        cfg.setAllowedOrigins(List.of("https://localhost:3000", frontUri, backUri));
 
         cfg.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS","HEAD"));
         cfg.setAllowedHeaders(List.of("*"));

--- a/src/main/java/com/koa/koalamailman/global/security/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/koa/koalamailman/global/security/handler/OAuth2FailureHandler.java
@@ -10,6 +10,8 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
+import org.springframework.web.util.UriComponentsBuilder;
+
 import java.io.IOException;
 
 @Component
@@ -22,7 +24,10 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-        String redirectUrl = frontUri + "/login/fail?error=" + exception.getMessage();
+        String redirectUrl = UriComponentsBuilder.fromHttpUrl(frontUri)
+                .path("/login/fail")
+                .queryParam("error", exception.getMessage())
+                .build().toUriString();
         response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/java/com/koa/koalamailman/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/koa/koalamailman/global/security/handler/OAuth2SuccessHandler.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -33,6 +34,10 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private String loginRedirectUri;
     @Value("${app.oauth2.domain}")
     private String cookieDomain;
+    @Value("${app.oauth2.local-redirect-uri}")
+    private String localRedirectUri;
+    @Value("${app.oauth2.local-test-emails:#{null}}")
+    private List<String> localTestEmails;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -55,18 +60,10 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         ResponseCookie cookie = cookieProvider.setRefreshTokenCookie(refreshToken);
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-        String targetUrl;
-
-        // 프론트엔드 로컬 테스트용 계정
-        if (registrationId.equals("google") && (email.equals("mamonde456@gmail.com") || email.equals("kwakjungah0605@gmail.com"))) {
-            targetUrl = UriComponentsBuilder
-                    .fromHttpUrl("https://localhost:3000")
-                    .build().toUriString();
-        } else {
-            targetUrl = UriComponentsBuilder
-                    .fromHttpUrl(loginRedirectUri)
-                    .build().toUriString();
-        }
+        boolean isLocalTest = localTestEmails != null && localTestEmails.contains(email);
+        String targetUrl = UriComponentsBuilder
+                .fromHttpUrl(isLocalTest ? localRedirectUri : loginRedirectUri)
+                .build().toUriString();
 
         response.sendRedirect(targetUrl);
     }

--- a/src/main/java/com/koa/koalamailman/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/koa/koalamailman/global/security/handler/OAuth2SuccessHandler.java
@@ -1,7 +1,6 @@
 package com.koa.koalamailman.global.security.handler;
 
 import com.koa.koalamailman.user.application.UserAuthUseCase;
-import com.koa.koalamailman.auth.application.AccessTokenService;
 import com.koa.koalamailman.auth.application.RefreshTokenService;
 import com.koa.koalamailman.user.domain.OAuthProvider;
 import com.koa.koalamailman.user.domain.User;
@@ -26,7 +25,6 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
-    private final AccessTokenService accessTokenService;
     private final CookieProvider cookieProvider;
     private final RefreshTokenService refreshTokenService;
     private final UserAuthUseCase userAuthUseCase;
@@ -51,7 +49,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
 
         User user = userAuthUseCase.findOrCreate(provider, providerId, name, email);
-        String accessToken = accessTokenService.createAccessToken(user);
 
         String refreshToken = refreshTokenService.createRefreshToken(user);
 
@@ -63,13 +60,11 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         // 프론트엔드 로컬 테스트용 계정
         if (registrationId.equals("google") && (email.equals("mamonde456@gmail.com") || email.equals("kwakjungah0605@gmail.com"))) {
             targetUrl = UriComponentsBuilder
-                    .fromHttpUrl("http://localhost:3000")
-                    .queryParam("access_token", accessToken)
+                    .fromHttpUrl("https://localhost:3000")
                     .build().toUriString();
         } else {
             targetUrl = UriComponentsBuilder
                     .fromHttpUrl(loginRedirectUri)
-                    .queryParam("access_token", accessToken)
                     .build().toUriString();
         }
 

--- a/src/main/java/com/koa/koalamailman/global/token/CookieProvider.java
+++ b/src/main/java/com/koa/koalamailman/global/token/CookieProvider.java
@@ -14,7 +14,7 @@ public class CookieProvider {
     public ResponseCookie setRefreshTokenCookie(String refreshToken) {
         return ResponseCookie.from("refresh_token", refreshToken)
                 .httpOnly(true)
-                .secure(false) //개발 환경에서 잠시 false로 추후 https 적용 시 true
+                .secure(true)
                 .path("/")
                 .maxAge(Duration.ofMillis(refreshTokenExpiration))
                 .sameSite("Lax")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,9 +9,11 @@ server:
 
 app:
   oauth2:
-    front-uri: ${FRONT_URI:https://ringdong.kr}
-    back-uri: ${BACK_URI:https://ringdong.kr}
-    domain: ${COOKIE_DOMAIN:ringdong.kr}
+    front-uri: ${FRONT_URI}
+    back-uri: ${BACK_URI}
+    domain: ${COOKIE_DOMAIN}
+    local-redirect-uri: ${LOCAL_REDIRECT_URI:https://localhost:3000}
+    local-test-emails: ${LOCAL_TEST_EMAILS:}
 
 spring:
   application:


### PR DESCRIPTION
## 🔖 Description
<!-- 변경 사항과 관련 이슈를 간단히 작성해주세요.
     "어떻게" 보다는 "무엇을, 왜" 수정했는지를 중점적으로 설명해주세요. -->

Resolves: #137

1. 토큰 전달 방식 개선

  - 로그인 성공 시 refresh token만 HttpOnly Cookie로 설정 후 redirect
  - redirect URL에서 ?access_token=... 쿼리 파라미터 제거
  - 프론트엔드가 POST /api/auth/refresh 호출로 access token 발급
  - CSRF 방지용 state 파라미터는 기존과 동일하게 유지

 2.  쿠키 보안 강화

  - CookieProvider secure 속성 false → true (HTTPS 전용)
  - 로컬 redirect URL http://localhost:3000 → https://localhost:3000

 3. 로컬 테스트 계정 하드코딩 제거

  - 특정 이메일 하드코딩 제거
  - LOCAL_REDIRECT_URI, LOCAL_TEST_EMAILS 환경변수로 분리

4.  버그 수정

  - /api/auth/refresh 발급 access token에 refresh token 만료 시간이 적용되던 버그 수정 → jwt.access.expiration 적용
  - CORS 허용 origin http://localhost:3000 → https://localhost:3000
  - OAuth2 로그인 실패 시 error 메시지 URL 인코딩 없이 redirect URL에 노출되던 문제 수정



## 📂 PR Type
이번 PR에는 어떤 변경 사항이 포함되었나요?

- [ ] ✨ 새로운 기능 추가
- [x] 🔨 코드 리팩토링
- [x] 🐛 버그 수정
- [ ] ✅ 테스트 추가
- [ ] 📦 빌드/패키지 매니저 수정
- [ ] 📝 주석 추가 및 수정
- [ ] 📚 문서 수정
- [ ] 🗂 파일/폴더명 수정
- [ ] 🗑 파일/폴더 삭제


## ✅ Checklist
PR이 다음 요구 사항을 충족하는지 확인해주세요.

- [ ] 커밋 메시지가 컨벤션에 맞게 작성되었습니다.
- [ ] `dev` 브랜치를 최신 상태로 맞추고 conflict를 해결했습니다.
- [ ] 기능/버그 수정에 대한 테스트를 완료했습니다.


## 📌 ETC
<!-- 리뷰어가 참고하면 좋을 추가 사항이나 주의할 점이 있다면 적어주세요. -->
