### PR TITLE
fix: CookieProvider에 쿠키 domain 속성 적용

### DIFF
--- a/src/main/java/com/koa/koalamailman/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/koa/koalamailman/global/security/handler/OAuth2SuccessHandler.java
@@ -32,8 +32,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     @Value("${app.oauth2.login-redirect-uri}")
     private String loginRedirectUri;
-    @Value("${app.oauth2.domain}")
-    private String cookieDomain;
     @Value("${app.oauth2.local-redirect-uri}")
     private String localRedirectUri;
     @Value("${app.oauth2.local-test-emails:#{null}}")

--- a/src/main/java/com/koa/koalamailman/global/token/CookieProvider.java
+++ b/src/main/java/com/koa/koalamailman/global/token/CookieProvider.java
@@ -11,6 +11,9 @@ import java.time.Duration;
 public class CookieProvider {
     @Value("${jwt.refresh.expiration}")
     private long refreshTokenExpiration;
+    @Value("${app.oauth2.domain}")
+    private String cookieDomain;
+
     public ResponseCookie setRefreshTokenCookie(String refreshToken) {
         return ResponseCookie.from("refresh_token", refreshToken)
                 .httpOnly(true)
@@ -18,6 +21,7 @@ public class CookieProvider {
                 .path("/")
                 .maxAge(Duration.ofMillis(refreshTokenExpiration))
                 .sameSite("Lax")
+                .domain(cookieDomain)
                 .build();
     }
 }


### PR DESCRIPTION
## 🔖 Description
<!-- 변경 사항과 관련 이슈를 간단히 작성해주세요.
     "어떻게" 보다는 "무엇을, 왜" 수정했는지를 중점적으로 설명해주세요. -->

Resolves: #(Issue Number)
  `COOKIE_DOMAIN` 환경변수가 설정되어 있었지만 실제 쿠키 발급 시 `domain` 속성이 적용되지 않아, refresh_token 쿠키가 `api.koreankoala.com`에만 귀속되고 있었습니다.


## 📂 PR Type
이번 PR에는 어떤 변경 사항이 포함되었나요?

- [ ] ✨ 새로운 기능 추가
- [ ] 🔨 코드 리팩토링
- [x] 🐛 버그 수정
- [ ] ✅ 테스트 추가
- [ ] 📦 빌드/패키지 매니저 수정
- [ ] 📝 주석 추가 및 수정
- [ ] 📚 문서 수정
- [ ] 🗂 파일/폴더명 수정
- [ ] 🗑 파일/폴더 삭제


## ✅ Checklist
PR이 다음 요구 사항을 충족하는지 확인해주세요.

- [ ] 커밋 메시지가 컨벤션에 맞게 작성되었습니다.
- [ ] `dev` 브랜치를 최신 상태로 맞추고 conflict를 해결했습니다.
- [ ] 기능/버그 수정에 대한 테스트를 완료했습니다.


## 📌 ETC
<!-- 리뷰어가 참고하면 좋을 추가 사항이나 주의할 점이 있다면 적어주세요. -->
